### PR TITLE
meta: Force hard reset on the meta-data repository.

### DIFF
--- a/files/usr/local/bin/update-meta
+++ b/files/usr/local/bin/update-meta
@@ -15,7 +15,7 @@ GIT_REVISION=$(getCurrentVersion)
 git fetch -q origin master
 
 # Revert all local changes and merge 
-git reset -q origin/master
+git reset -q --hard origin/master
 
 git pull -q origin master 
 


### PR DESCRIPTION
Since the data in the icvpn-meta repo is managed upstream.
Local changes will undermine the purpose of the whole approach to
distribute machine readable and processable meta data for configurations.
