### PR TITLE
meta: create configuration if not exists

### DIFF
--- a/files/usr/local/bin/update-meta
+++ b/files/usr/local/bin/update-meta
@@ -22,7 +22,7 @@ git pull -q origin master
 # Get current version hash
 GIT_NEW_REVISION=$(getCurrentVersion)
 
-if [ $GIT_REVISION != $GIT_NEW_REVISION ]
+if [ $GIT_REVISION != $GIT_NEW_REVISION ] || [ ! -f /etc/bind/named.conf.icvpn-meta ]
 then
   # Version has changed we need to update
   ICVPN=${ICVPN:-0}


### PR DESCRIPTION
In the first run configuration file is not created since we just checked out the icvpn-meta repo and thus no new patches are available, hence no config is created.
