### PR TITLE
nrpe: Add nagios plugins package

### DIFF
--- a/manifests/monitor/nrpe.pp
+++ b/manifests/monitor/nrpe.pp
@@ -4,6 +4,8 @@ class ffnord::monitor::nrpe ( $allowed_hosts
     'nagios-nrpe-server': 
       ensure => installed,
       notify => Service['nagios-nrpe-server'];
+    'nagios-plugins':
+      ensure => installed;
     'cron-apt': 
       ensure => installed;
   } 


### PR DESCRIPTION
When the host is configured to not installed recommends this package will not be installed by default.
