### PR TITLE
meta: Remove requirement of cloned icvpn repo.

### DIFF
--- a/manifests/resources/meta.pp
+++ b/manifests/resources/meta.pp
@@ -44,7 +44,6 @@ class ffnord::resources::meta {
       user => root,
       minute => '0',
       require => [
-        Vcsrepo['/etc/tinc/icvpn/'],
         File['/usr/local/bin/update-meta']
       ];
   }


### PR DESCRIPTION
The icvpn repo is cloned to /etc/tinc/icvpn/ by the tinc.pp manifest. In case the ffnord::bird6::icvpn type is not declared the resource is not declared as well. 
