### PR TITLE
fix define ffnord::batman-adv

### DIFF
--- a/files/etc/iptables.d/001-FORWARD-PreProcessing
+++ b/files/etc/iptables.d/001-FORWARD-PreProcessing
@@ -1,6 +1,7 @@
 # Initial processing of input chain on filter table
 # Packages which are not directly ACCEPTed or DROPed are pushed to the forward chain
 ip46tables -N forward
+ip46tables -N bat-forward
 ip46tables -N mesh-forward
 ip46tables -N wan-forward
 

--- a/files/etc/iptables.d/001-INPUT-PreProcessing
+++ b/files/etc/iptables.d/001-INPUT-PreProcessing
@@ -1,6 +1,7 @@
 # Initial processing of input chain on filter table
 # Packages which are not directly ACCEPTed or DROPed are pushed to the input chain
 ip46tables -N input
+ip46tables -N bat-input
 ip46tables -N mesh-input
 ip46tables -N wan-input
 

--- a/files/etc/iptables.d/900-FORWARD-drop
+++ b/files/etc/iptables.d/900-FORWARD-drop
@@ -1,4 +1,5 @@
 # Drop all packages which are not ACCEPTed to this point
 ip46tables -A forward -j DROP
+ip46tables -A bat-forward  -j DROP
 ip46tables -A mesh-forward -j DROP
 ip46tables -A wan-forward  -j DROP

--- a/files/etc/iptables.d/900-INPUT-drop
+++ b/files/etc/iptables.d/900-INPUT-drop
@@ -1,4 +1,5 @@
 # Drop all packages not ACCEPTed to this point
 ip46tables -A input -j DROP
+ip46tables -A bat-input -j DROP
 ip46tables -A mesh-input -j DROP
 ip46tables -A wan-input -j DROP

--- a/manifests/batman-adv.pp
+++ b/manifests/batman-adv.pp
@@ -12,32 +12,9 @@ define ffnord::batman-adv( $mesh_code
   }
 
   file_line {
-   'root_bashrc_batffki':
+   "root_bashrc_bat${mesh_code}":
      path => '/root/.bashrc',
      line => "alias batctl-${mesh_code}='batctl -m bat-${mesh_code}'"
-  }
-
-  # Define Firewall rules for services on bat interfaces, e.g. alfred
-  # introducing the "bat" chain
-  file {
-    '/etc/iptables.d/002-batman-chains':
-     ensure => file,
-     owner => 'root',
-     group => 'root',
-     mode => '0644',
-     content => "ip46tables -N bat-forward\nip46tables -N bat-input",
-     require => [File['/etc/iptables.d/']],
-  }
-
-
-  file {
-    '/etc/iptables.d/900-batman-DROP':
-     ensure => file,
-     owner => 'root',
-     group => 'root',
-     mode => '0644',
-     content => "ip46tables -A bat-forward -j DROP\nip46tables -A bat-input -j DROP",
-     require => [File['/etc/iptables.d/']],
   }
 
   ffnord::firewall::device { "bat-${mesh_code}":


### PR DESCRIPTION
I merged the iptables chains for batman into the existing files and fixed the bash alias so one can properly use the ffnord::batman-adv define.
