### PR TITLE
bird6: use direct mode for local route exchange

### DIFF
--- a/templates/etc/bird/bird6.conf.erb
+++ b/templates/etc/bird/bird6.conf.erb
@@ -77,7 +77,7 @@ protocol pipe pipe_kernel_main_mesh {
 template bgp local_mesh {
   import where is_ula(); # Is that a wise decision?
   export where source = RTS_BGP;
-  gateway direct;
+  direct;
   next hop self;
 };
 


### PR DESCRIPTION
this implies gateway direct mode, but gateway direct mode needs directly connected peers, otherwise an error is thrown
