### PR TITLE
routing: remove unreachable defaults from mesh table (42)

### DIFF
--- a/files/etc/openvpn/anonvpn-up.sh
+++ b/files/etc/openvpn/anonvpn-up.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 sysctl -w net.ipv4.conf.${1}.rp_filter=0
-ip route replace 0.0.0.0/1 via $4 table 42
-ip route replace 128.0.0.0/1 via $4 table 42
+ip route replace default via $4 table 42
 ip rule del pref 30000 || true
 ip rule add from $4 lookup 42 pref 30000
 exit 0

--- a/templates/etc/network/mesh-bridge.erb
+++ b/templates/etc/network/mesh-bridge.erb
@@ -6,7 +6,6 @@ iface br-<%= @mesh_code %> inet6 static
   pre-up    /sbin/ip -6 rule add pref 31001 iif $IFACE unreachable
   post-down /sbin/ip -6 rule del pref 31000 iif $IFACE table 42
   post-down /sbin/ip -6 rule del pref 31001 iif $IFACE unreachable
-  pre-up     /sbin/ip -6 route replace unreachable default table 42 || true
   post-up    /sbin/ip -6 route replace <%= @mesh_ipv6_prefix %>/<%= @mesh_ipv6_prefixlen %> dev $IFACE table 42
   address <%= @mesh_ipv6_address %>
   # TODO bits configurable
@@ -16,7 +15,6 @@ iface br-<%= @mesh_code %> inet static
   pre-up    /sbin/ip rule add pref 31001 iif $IFACE unreachable
   post-down /sbin/ip rule del pref 31000 iif $IFACE table 42
   post-down /sbin/ip rule del pref 31001 iif $IFACE unreachable
-  pre-up     /sbin/ip route replace unreachable default table 42 || true
   post-up    /sbin/ip route add <%= @mesh_ipv4_prefix %>/<%= @mesh_ipv4_prefixlen %> dev $IFACE table 42
   address <%= @mesh_ipv4_address %>
   netmask <%= @mesh_ipv4_netmask %>


### PR DESCRIPTION
as we always have two rules (lookup mesh and unreachable) one after another,
the unreachable default route in the mesh table (42) shouln't be needed anymore
