### PR TITLE
ntp: disable monlist query

### DIFF
--- a/templates/etc/ntp.conf.erb
+++ b/templates/etc/ntp.conf.erb
@@ -22,3 +22,7 @@ restrict -6 default kod notrap nomodify nopeer
 # Local users may interrogate the ntp server more closely.
 restrict 127.0.0.1
 restrict ::1
+
+# Disable the monlist request as this is associated with ntp
+# amplification attacks
+disable monitor


### PR DESCRIPTION
disable monlist query as this is associated with dns amplification attacks and usually not needed.
there are no negative side effects known to me
