### PR TITLE
ip_netmask: use ip_prefixlen to generate parameter for mask() function

### DIFF
--- a/lib/puppet/parser/functions/ip_netmask.rb
+++ b/lib/puppet/parser/functions/ip_netmask.rb
@@ -13,12 +13,12 @@ module Puppet::Parser::Functions
   EOS
   ) do |args|
     ip_address = args[0]
+    Puppet::Parser::Functions.function('ip_prefixlen')
     if IPAddr.new(ip_address).ipv6?()
       net = IPAddr.new('ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff')
-      return net.mask(ip_address).to_string()
     else
       net = IPAddr.new('255.255.255.255')
-      return net.mask(ip_address).to_string()
     end
+    return net.mask(function_ip_prefixlen([ip_address])).to_string()
   end
 end


### PR DESCRIPTION
example: ip_netmask returned 10.112.0.0 when 10.112.42.1/18 was given as parameter. now the correct output is produced
