### PR TITLE
Increase size of neighbour table size for IPv{4,6}

### DIFF
--- a/files/etc/sysctl.d/routing.conf
+++ b/files/etc/sysctl.d/routing.conf
@@ -5,3 +5,10 @@ net.ipv4.ip_forward=1
 net.ipv6.conf.all.forwarding=1
 
 net.ipv4.icmp_errors_use_inbound_ifaddr=1
+
+net.ipv6.neigh.default.gc_thresh1=1024
+net.ipv6.neigh.default.gc_thresh2=2048
+net.ipv6.neigh.default.gc_thresh3=4096
+net.ipv4.neigh.default.gc_thresh1=1024
+net.ipv4.neigh.default.gc_thresh2=2048
+net.ipv4.neigh.default.gc_thresh3=4096


### PR DESCRIPTION
By this we get rid of neighbour table overflow messages, e.g. seen in hamburg where the network has reached a size that interferes with the default neighbour table sizes
