### PR TITLE
bird6: also exchange other freifunk routes within mesh

### DIFF
--- a/templates/etc/bird/bird6.conf.erb
+++ b/templates/etc/bird/bird6.conf.erb
@@ -31,6 +31,13 @@ function is_ula() {
   return (net ~ [ fc00::/7{48,64} ]);
 };
 
+# Filter function to check if an IPv6 Route is from
+# a Freifunk range.
+function is_freifunk() {
+  return net ~ [ 2001:0bf7::/32+,   # Foerderverein freie Netzwerke e.V.
+                 2a03:2260::/29+ ]; # Freifunk Rheinland e.V.
+}
+
 # don't use kernel's routes for bird, but export bird's 
 # routes to kernel table 42. 
 #
@@ -75,7 +82,7 @@ protocol pipe pipe_kernel_main_mesh {
 
 # template for local route exchange via bgp
 template bgp local_mesh {
-  import where is_ula(); # Is that a wise decision?
+  import where is_ula() || is_freifunk();
   export where source = RTS_BGP;
   direct;
   next hop self;


### PR DESCRIPTION
there are other prefixes used by freifunk communities apart from the ula range
