### PR TITLE
update-common: Drop non error output

### DIFF
--- a/files/usr/local/include/ffnord-update.common
+++ b/files/usr/local/include/ffnord-update.common
@@ -16,7 +16,7 @@ case $2 in
       pull $@
     else 
       cd "$REPOSITORY"
-      git pull
+      git pull > /dev/null
     fi
     ;;
   reload)


### PR DESCRIPTION
At the ffki-noc we have an null-mailer on every gateway, which reports any output from cron jobs. Therefore all scripts should be as silent as possible, otherwise we get information spamd. Which significantly reduces the problem awareness. 

So this reduces the output in the generic pull case.