### PR TITLE
check-gateway: ensure we also have unreachable route

### DIFF
--- a/files/usr/local/bin/check-gateway
+++ b/files/usr/local/bin/check-gateway
@@ -8,11 +8,17 @@ MAINTENANCE=${MAINTENANCE:-0}
 
 if test $MAINTENANCE -eq 0; then
 
-    # ensure that we have the appropriate rule
+    # ensure that we have the appropriate rules
     /sbin/ip rule | grep 32000 2>&1> /dev/null
     if [[ $? -ne 0 ]]
     then
         /sbin/ip rule add from all fwmark 0x1 table 42 preference 32000
+    fi
+
+    /sbin/ip rule | grep 32001 2>&1> /dev/null
+    if [[ $? -ne 0 ]]
+    then
+        /sbin/ip rule add from all fwmark 0x1 unreachable preference 32001
     fi
 
     ping -q -m 1 $GW_CONTROL_IP -c 4 -i 1 -W 5 >/dev/null 2>&1


### PR DESCRIPTION
otherwise packets might get to the main routing table if we
do not have a default route in table 42