### PR TITLE
fastd-query: Add missing dependency.

### DIFF
--- a/manifests/resources/fastd.pp
+++ b/manifests/resources/fastd.pp
@@ -17,7 +17,10 @@ class ffnord::resources::fastd {
       source => 'puppet:///modules/ffnord/usr/local/bin/fastd-query';
   }
 
-  package { ['jq','socat']: ensure => installed; }
+  package { ['jq','socat']:
+    ensure => installed,
+    require => Class[ffnord::resources::repos];
+  }
 }
 
 class ffnord::resources::fastd::auto_fetch_keys {


### PR DESCRIPTION
Otherwise the required backports repository may not be enabled,
which would render jq unavailable.