### PR TITLE
bird,meta: Respect inclusion configuration during meta update.

### DIFF
--- a/files/usr/local/bin/update-meta
+++ b/files/usr/local/bin/update-meta
@@ -4,6 +4,9 @@ REPOSITORY=/var/lib/icvpn-meta/
 
 reload() {
   ICVPN=${ICVPN:-0}
+  INCLUDE_BIRD4=${INCLUDE_BIRD4:-0}
+  INCLUDE_BIRD6=${INCLUDE_BIRD6:-0}
+
 
   # Build-Up parameters for excluded zones
   excluded_zones=''
@@ -19,17 +22,21 @@ reload() {
   if [ $ICVPN = 1 ] ; then
     excluded_peers=""
     [ -n "${ICVPN_EXCLUDE}" ] && excluded_peers="-x ${ICVPN_EXCLUDE}"
-    echo
-    echo bird6: regenerating icvpn peers
-    /opt/icvpn-scripts/mkbgp -6 -s /var/lib/icvpn-meta -d icvpn $excluded_peers > /etc/bird/bird6.conf.d/icvpn-peers.conf
-    echo bird6: reload 
-    # We only want errors
-    /usr/sbin/birdc6 configure 1>/dev/null
-    echo
-    echo bird: regenerating icvpn peers
-    /opt/icvpn-scripts/mkbgp -4 -s /var/lib/icvpn-meta -d icvpn $excluded_peers > /etc/bird/bird.conf.d/icvpn-peers.conf
-    echo bird: reload
-    # We only want errors
-    /usr/sbin/birdc configure 1>/dev/null
+    if [ "$INCLUDE_BIRD6" = "true" ]; then
+      echo
+      echo bird6: regenerating icvpn peers
+      /opt/icvpn-scripts/mkbgp -6 -s /var/lib/icvpn-meta -d icvpn $excluded_peers > /etc/bird/bird6.conf.d/icvpn-peers.conf
+      echo bird6: reload
+      # We only want errors
+      /usr/sbin/birdc6 configure 1>/dev/null
+    fi
+    if [ "$INCLUDE_BIRD4" = "true" ]; then
+      echo
+      echo bird: regenerating icvpn peers
+      /opt/icvpn-scripts/mkbgp -4 -s /var/lib/icvpn-meta -d icvpn $excluded_peers > /etc/bird/bird.conf.d/icvpn-peers.conf
+      echo bird: reload
+      # We only want errors
+      /usr/sbin/birdc configure 1>/dev/null
+    fi
   fi
 }

--- a/manifests/resources/bird.pp
+++ b/manifests/resources/bird.pp
@@ -1,4 +1,7 @@
-class ffnord::resources::bird {
+class ffnord::resources::bird (
+  $include_bird4 = $ffnord::params::include_bird4,
+  $include_bird6 = $ffnord::params::include_bird6,
+) inherits ffnord::params {
   file {
    '/etc/bird/':
      ensure => directory,
@@ -16,4 +19,10 @@ class ffnord::resources::bird {
     protos => ['tcp'],
     chains => ['mesh']
   }
+
+  ffnord::resources::ffnord::field {
+    "INCLUDE_BIRD4": value => $include_bird4;
+    "INCLUDE_BIRD6": value => $include_bird6;
+  }
+
 }


### PR DESCRIPTION
This will store the inclusion information for bird4/6 in /etc/ffnord,
thus we can decide to call reload funcitons on bird4 respective bird6
only if they shall be running.