### PR TITLE
fastd improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ ffnord::mesh { 'mesh_ffgc':
       mesh_code    => "ffgc",
       mesh_as      => 65035,
       mesh_mac     => "de:ad:be:ef:de:ad",
+      vpn_mac      => "de:ad:be:ff:de:ad",
       mesh_ipv6    => "fd35:f308:a922::ff00/64,
       mesh_ipv4    => "10.35.0.1/19",
       mesh_mtu     => "1426",
@@ -153,6 +154,7 @@ ffnord :: mesh { '<mesh_code>':
   mesh_code,        # Code of your community, e.g.: ffgc
   mesh_as,          # AS of your community
   mesh_mac,         # mac address mesh device: 52:54:00:bd:e6:d4
+  vpn_mac,          # mac address vpn device, ideally != mesh_mac and unique
   mesh_ipv6,        # ipv6 address of mesh device in cidr notation, e.g. 10.35.0.1/19
   mesh_mtu,         # mtu used, default only suitable for fastd via ipv4
   range_ipv4,       # ipv4 range allocated to community, this might be different to

--- a/files/etc/sysctl.d/routing.conf
+++ b/files/etc/sysctl.d/routing.conf
@@ -12,3 +12,6 @@ net.ipv6.neigh.default.gc_thresh3=4096
 net.ipv4.neigh.default.gc_thresh1=1024
 net.ipv4.neigh.default.gc_thresh2=2048
 net.ipv4.neigh.default.gc_thresh3=4096
+
+net.core.wmem_max=8388608
+net.core.wmem_default=8388608

--- a/manifests/fastd.pp
+++ b/manifests/fastd.pp
@@ -1,6 +1,7 @@
 define ffnord::fastd( $mesh_name
                      , $mesh_code
                      , $mesh_mac
+                     , $vpn_mac
                      , $mesh_mtu = 1426
 
                      , $fastd_secret

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@ define ffnord::mesh(
   $mesh_code,        # Code of your community, e.g.: ffgc
   $mesh_as,          # AS of your community
   $mesh_mac,         # mac address mesh device: 52:54:00:bd:e6:d4
+  $vpn_mac,          # mac address vpn device, ideally != mesh_mac and unique
   $mesh_mtu = 1426,  # mtu used, default only suitable for fastd via ipv4
   $range_ipv4,       # ipv4 range allocated to community in cidr notation, e.g. 10.35.0.1/16
   $mesh_ipv4,        # ipv4 address in cidr notation, e.g. 10.35.0.1/19
@@ -65,6 +66,7 @@ define ffnord::mesh(
     mesh_name => $mesh_name,
     mesh_code => $mesh_code,
     mesh_mac  => $mesh_mac,
+    vpn_mac   => $vpn_mac,
     mesh_mtu  => $mesh_mtu,
     fastd_secret => $fastd_secret,
     fastd_port   => $fastd_port,

--- a/templates/etc/fastd/fastd.conf.erb
+++ b/templates/etc/fastd/fastd.conf.erb
@@ -15,7 +15,7 @@ status socket "/var/run/fastd-status.<%= @mesh_code %>.sock";
 include peers from "peers";
 on up "
  modprobe batman-adv
- ip link set address <%= @mesh_mac %> dev $INTERFACE
+ ip link set address <%= @vpn_mac %> dev $INTERFACE
  /usr/sbin/batctl -m bat-<%= @mesh_code %> if add $INTERFACE
  ip link set address <%= @mesh_mac %> dev bat-<%= @mesh_code %>
  ifup bat-<%= @mesh_code %>


### PR DESCRIPTION
wmem increase to have a send queue of sufficient size.

vpn_mac introduced to allow setting a separate mac for the vpn interface,
otherwise we get a lot of messages like "received packet on bat-ffhh with own address as source address".
as the vpn interface is a client in the mesh and the same holds for the bat interface, these macs should differ.