### PR TITLE
ntp: fix syntax of restrict option

### DIFF
--- a/manifests/ntp.pp
+++ b/manifests/ntp.pp
@@ -61,7 +61,7 @@ define ffnord::ntp::allow(
   file_line {
     "ntp_restrict_v6_${name}":
     path => '/etc/ntp.conf',
-    line => "restrict -6 ${ipv6_prefix} mask ${ipv6_netmask} nomodify notrap nopeer",
+    line => "restrict ${ipv6_prefix} mask ${ipv6_netmask} nomodify notrap nopeer",
     require => File['/etc/ntp.conf'];
   }
 


### PR DESCRIPTION
somehow using -6 gives error messages in syslog on startup
and does not apply the rule. omitting the -6, everything works as expected