### PR TITLE
Add options peer_limit and use_blacklist

### DIFF
--- a/manifests/fastd.pp
+++ b/manifests/fastd.pp
@@ -7,6 +7,8 @@ define ffnord::fastd( $mesh_name
                      , $fastd_port
 
                      , $fastd_peers_git
+                     , $peer_limit
+                     ; $use_blacklist
                      ) {
   #validate_re($mesh_mac, '^de:ad:be:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}$')
 
@@ -26,6 +28,14 @@ define ffnord::fastd( $mesh_name
       ensure => file,
              notify => Service[ffnord::resources::fastd],
              content => template('ffnord/etc/fastd/fastd.conf.erb');
+    "/etc/fastd/${mesh_code}-mesh-vpn/fastd-blacklist.sh":
+      ensure => file,
+             notify => Service[ffnord::resources::fastd],
+             content => template('ffnord/etc/fastd/fastd-blacklist.sh.erb');
+   "/etc/fastd/${mesh_code}-mesh-vpn/fastd-blacklist.json":
+      ensure => file,
+             notify => Service[ffnord::resources::fastd],
+             content => template('ffnord/etc/fastd/fastd-blacklist.json.erb');
     "/etc/fastd/${mesh_code}-mesh-vpn/secret.conf":
       ensure => file,
       source => $fastd_secret,

--- a/manifests/fastd.pp
+++ b/manifests/fastd.pp
@@ -8,7 +8,7 @@ define ffnord::fastd( $mesh_name
 
                      , $fastd_peers_git
                      , $peer_limit
-                     ; $use_blacklist
+                     , $use_blacklist
                      ) {
   #validate_re($mesh_mac, '^de:ad:be:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}$')
 
@@ -31,7 +31,8 @@ define ffnord::fastd( $mesh_name
     "/etc/fastd/${mesh_code}-mesh-vpn/fastd-blacklist.sh":
       ensure => file,
              notify => Service[ffnord::resources::fastd],
-             content => template('ffnord/etc/fastd/fastd-blacklist.sh.erb');
+             content => template('ffnord/etc/fastd/fastd-blacklist.sh.erb'),
+             mode => '0766';
    "/etc/fastd/${mesh_code}-mesh-vpn/fastd-blacklist.json":
       ensure => file,
              notify => Service[ffnord::resources::fastd],

--- a/manifests/fastd.pp
+++ b/manifests/fastd.pp
@@ -24,6 +24,9 @@ define ffnord::fastd( $mesh_name
     "/etc/fastd/${mesh_code}-mesh-vpn/":
       ensure =>directory,
              require => Package[ffnord::resources::fastd];
+    "/etc/fastd/${mesh_code}-mesh-vpn/backbone":
+      ensure =>directory,
+             require => Package[ffnord::resources::fastd];
     "/etc/fastd/${mesh_code}-mesh-vpn/fastd.conf":
       ensure => file,
              notify => Service[ffnord::resources::fastd],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,8 +12,8 @@ define ffnord::mesh(
   $fastd_peers_git,  # fastd peers
   $fastd_secret,     # fastd secret
   $fastd_port,       # fastd port
-  $peer_limit,       # optionally set peer limit
-  $use_blacklist,    # optionally use a blacklist approache
+  $peer_limit = -1,  # optionally set peer limit
+  $use_blacklist = "no",  # optionally use a blacklist approach; set to "yes" to enable
 
   $dhcp_ranges = [], # dhcp pool
   $dns_servers = [], # other dns servers in your network

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,8 @@ define ffnord::mesh(
   $fastd_peers_git,  # fastd peers
   $fastd_secret,     # fastd secret
   $fastd_port,       # fastd port
+  $peer_limit,       # optionally set peer limit
+  $use_blacklist,    # optionally use a blacklist approache
 
   $dhcp_ranges = [], # dhcp pool
   $dns_servers = [], # other dns servers in your network
@@ -68,6 +70,8 @@ define ffnord::mesh(
     mesh_mtu  => $mesh_mtu,
     fastd_secret => $fastd_secret,
     fastd_port   => $fastd_port,
+    peer_limit => $peer_limit,
+    use_blacklist => $use_blacklist,
     fastd_peers_git => $fastd_peers_git;
   } ->
   ffnord::radvd { "br-${mesh_code}":

--- a/templates/etc/fastd/fastd-blacklist.json.erb
+++ b/templates/etc/fastd/fastd-blacklist.json.erb
@@ -1,0 +1,14 @@
+{
+  "peers": 
+  [
+    {
+      "pubkey": "5f4965072a034996589112e0101fcaa30360e8d36b22fd86f5d0512effd85286",
+      "comment": "2015-01-08 interconnecting CHRlS"
+    },
+    {
+      "pubkey": "d05810068dfbe559463de2ba6cee861c3a910560f446c78fd4479f4a508e052d",
+      "comment": "Bridged communities! //CyrusFox"
+    }
+  ]
+}
+

--- a/templates/etc/fastd/fastd-blacklist.sh.erb
+++ b/templates/etc/fastd/fastd-blacklist.sh.erb
@@ -1,0 +1,8 @@
+#!/bin/bash
+PEER_KEY=$1
+
+if /bin/grep -Fq $PEER_KEY /etc/fastd/<%= @mesh_code %>-mesh-vpn/fastd-blacklist.json; then
+        exit 1
+else
+        exit 0
+fi

--- a/templates/etc/fastd/fastd-blacklist.sh.erb
+++ b/templates/etc/fastd/fastd-blacklist.sh.erb
@@ -1,5 +1,5 @@
 #!/bin/bash
-PEER_KEY=$1
+# PEER_KEY should be set, see http://fastd.readthedocs.org/en/v15/manual/config.html
 
 if /bin/grep -Fq $PEER_KEY /etc/fastd/<%= @mesh_code %>-mesh-vpn/fastd-blacklist.json; then
         exit 1

--- a/templates/etc/fastd/fastd.conf.erb
+++ b/templates/etc/fastd/fastd.conf.erb
@@ -12,7 +12,20 @@ hide mac addresses yes;
 include "secret.conf";
 mtu <%= @mesh_mtu %>; # 1492 - IPv{4,6} Header - fastd Header...
 status socket "/var/run/fastd-status.<%= @mesh_code %>.sock";
-include peers from "peers";
+peer group "nodes" {
+  include peers from "peers";
+<% if @peer_limit %>
+   peer limit <%= @peer_limit %>;
+<% end %>
+}
+peer group "backbone" {
+  include peers from "backbone";
+}
+<% if @use_blacklist %>
+on verify "
+  /etc/fastd/<%= @mesh_code %>-mesh-vpn/fastd-blacklist.sh $PEER_KEY
+";
+<% end %>
 on up "
  modprobe batman-adv
  ip link set address <%= @mesh_mac %> dev $INTERFACE

--- a/templates/etc/fastd/fastd.conf.erb
+++ b/templates/etc/fastd/fastd.conf.erb
@@ -14,16 +14,14 @@ mtu <%= @mesh_mtu %>; # 1492 - IPv{4,6} Header - fastd Header...
 status socket "/var/run/fastd-status.<%= @mesh_code %>.sock";
 peer group "nodes" {
   include peers from "peers";
-<% if @peer_limit %>
-   peer limit <%= @peer_limit %>;
-<% end %>
-}
+<% if @peer_limit.to_i > 0 %>  peer limit <%= @peer_limit %>;
+<% end %>}
 peer group "backbone" {
   include peers from "backbone";
 }
-<% if @use_blacklist %>
+<% if @use_blacklist == "yes" %>
 on verify "
-  /etc/fastd/<%= @mesh_code %>-mesh-vpn/fastd-blacklist.sh $PEER_KEY
+  /etc/fastd/<%= @mesh_code %>-mesh-vpn/fastd-blacklist.sh
 ";
 <% end %>
 on up "


### PR DESCRIPTION
Split backbone (other gateways) and peers; adding an option to add a limit to the fastd.conf for the peers. Adding another option to use the "blacklist feature", i. e. have a list of unwanted peers, anyone else may connect (see https://github.com/ffruhr/fastdbl).