### PR TITLE
maintenance: Stop/Start dhcpd

### DIFF
--- a/files/usr/local/bin/maintenance
+++ b/files/usr/local/bin/maintenance
@@ -10,12 +10,14 @@ case $1 in
   on)
     sed -i -e 's/^MAINTENANCE=.*$/MAINTENANCE='$(date +%s)'/' /etc/ffnord
     /etc/init.d/radvd stop
+    /etc/init.d/isc-dhcp-server stop
     update-rc.d radvd remove
     update-rc.d isc-dhcp-server remove
     ;;
   off)
     sed -i -e 's/^MAINTENANCE=.*$/MAINTENANCE=0/' /etc/ffnord
     /etc/init.d/radvd start
+    /etc/init.d/isc-dhcp-server start
     update-rc.d radvd defaults
     update-rc.d isc-dhcp-server defaults
     ;;


### PR DESCRIPTION
After a reboot in maintenance mode, after leaving maintenance, the dhcpd
is not started. On the other side it also not stopped when entering
maintenance.  This pr will fix this behaviour.