### PR TITLE
alfred: Disable alfred init script.

### DIFF
--- a/manifests/alfred.pp
+++ b/manifests/alfred.pp
@@ -41,7 +41,7 @@ class ffnord::alfred (
   service { 'alfred':
     ensure => running,
     hasrestart => true,
-    enable => true,
+    enable => false,
     require => [Exec['alfred'],File['/etc/init.d/alfred']];
    }
 


### PR DESCRIPTION
We start alfred via fastd up script. When the current script is runned
at init then none functional alfred processes are launched.