### PR TITLE
zabbix: allow multi-community monitoring and monitor fastd

### DIFF
--- a/files/etc/zabbix/fastd_connections.sh
+++ b/files/etc/zabbix/fastd_connections.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export FASTD_SOCKET=/var/run/fastd-status.$1.sock
+/usr/local/bin/fastd-query connections

--- a/files/etc/zabbix/fastd_connections6.sh
+++ b/files/etc/zabbix/fastd_connections6.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export FASTD_SOCKET=/var/run/fastd-status.$1.sock
+/usr/local/bin/fastd-query peers | grep '"address"' | grep -v any | grep '\[' | wc -l

--- a/manifests/fastd.pp
+++ b/manifests/fastd.pp
@@ -19,6 +19,13 @@ define ffnord::fastd( $mesh_name
       command => "/usr/lib/nagios/plugins/check_procs -c 1:1 -w 1:1 -C fastd -a \"${mesh_code}-mesh-vpn\"";
   }
 
+  ffnord::monitor::zabbix::check_script {
+    "${mesh_code}_fastdcons":
+      mesh_code => $mesh_code,
+      scriptname => "fastd_connections",
+      sudo => true;
+  }
+
   file {
     "/etc/fastd/${mesh_code}-mesh-vpn/":
       ensure =>directory,

--- a/manifests/fastd.pp
+++ b/manifests/fastd.pp
@@ -24,6 +24,10 @@ define ffnord::fastd( $mesh_name
       mesh_code => $mesh_code,
       scriptname => "fastd_connections",
       sudo => true;
+    "${mesh_code}_fastdcons6":
+      mesh_code => $mesh_code,
+      scriptname => "fastd_connections6",
+      sudo => true;
   }
 
   file {

--- a/manifests/monitor/zabbix.pp
+++ b/manifests/monitor/zabbix.pp
@@ -90,7 +90,7 @@ define ffnord::monitor::zabbix::check_script (
         mode => '0644',
         owner => 'root',
         group => 'root',
-        content => inline_template("UserParameter=${scriptname},${sudo_cmd}/opt/bin/zabbix/${scriptname}.sh ${mesh_code}"),
+        content => inline_template("UserParameter=${scriptname}_${mesh_code},${sudo_cmd}/opt/bin/zabbix/${scriptname}.sh ${mesh_code}"),
         require => Package['zabbix-agent'],
         notify => Service['zabbix-agent'];
     }


### PR DESCRIPTION
the userparameters are suffixed with the respective community name
or the keyword all if a parameter is monitored only once per machine. for the latter
conntrack might be a good example, while a per community monitoring
is needed e.g. for dhcp leases.

in addition to that, fastd is now monitored