### PR TITLE
Firewall adaptions

### DIFF
--- a/files/etc/iptables.d/900-FORWARD-drop
+++ b/files/etc/iptables.d/900-FORWARD-drop
@@ -1,4 +1,5 @@
 # Drop all packages which are not ACCEPTed to this point
+ip46tables -A FORWARD -j DROP
 ip46tables -A forward -j DROP
 ip46tables -A bat-forward  -j DROP
 ip46tables -A mesh-forward -j DROP

--- a/files/etc/iptables.d/900-INPUT-drop
+++ b/files/etc/iptables.d/900-INPUT-drop
@@ -1,4 +1,5 @@
 # Drop all packages not ACCEPTed to this point
+ip46tables -A INPUT -j DROP
 ip46tables -A input -j DROP
 ip46tables -A bat-input -j DROP
 ip46tables -A mesh-input -j DROP

--- a/files/usr/local/bin/build-firewall
+++ b/files/usr/local/bin/build-firewall
@@ -84,3 +84,5 @@ for rules in /etc/iptables.d/*; do
    echo "File: $rules"
    . $rules
 done
+
+/usr/sbin/service iptables-persistent save


### PR DESCRIPTION
we need to ensure that packets which are not udp or tcp are dropped at the end of the FORWARD and INPUT chain.

in addition to that, rules should be saved after build-firewall is executed. see #101 