### PR TITLE
Fixed revisions

### DIFF
--- a/manifests/alfred.pp
+++ b/manifests/alfred.pp
@@ -56,7 +56,7 @@ class ffnord::alfred (
 
   cron {
    'update-alfred-announce':
-     command => 'PATH=/opt/alfred/:/bin:/usr/bin:/sbin:$PATH /usr/local/bin/alfred-announce',
+     command => 'PATH=/opt/alfred/:/bin:/usr/bin:/sbin:/usr/sbin/:$PATH /usr/local/bin/alfred-announce',
      user    => root,
      minute  => '*',
      require => [Vcsrepo['/opt/alfred-announce'], Vcsrepo['/opt/alfred'],File['/usr/local/bin/alfred-announce']];

--- a/manifests/alfred.pp
+++ b/manifests/alfred.pp
@@ -4,6 +4,7 @@ class ffnord::alfred (
   vcsrepo { '/opt/alfred':
     ensure => present,
     provider => git,
+    revision => "dfb1ea4289387bc38d7fc7c51cfa9b0f3439e66f",
     source => "http://git.open-mesh.org/alfred.git";
   }
 
@@ -49,6 +50,7 @@ class ffnord::alfred (
     ensure => present,
     provider => git,
     source => "https://github.com/ffnord/ffnord-gateway-alfred.git",
+    revision => "816a6fa659f83da3d60e4ce9c88a1f3d4c1499dd",
     require => [Package['python3'],Package['ethtool']];
   }
 

--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -165,7 +165,8 @@ define ffnord::firewall::service (
 <% if @ports.length > 0 -%>
 <% @ports.each do |port| -%>
 <% if @rate_limit -%>
-rate_limit46 \"<%=@name%>\" <%=@rate_limit_seconds%> <%=@rate_limit_hitcount%> -A <%=chain%>-input -p <%=proto%> -m <%=proto%> --dport <%=port%><% if @source -%> -s <%=source%><% end -%>
+rate_limit46 \"<%=@name%>\" <%=@rate_limit_seconds%> <%=@rate_limit_hitcount%> -A <%=chain%>-input -p <%=proto%> -m <%=proto%> --dport <%=port%><% if @source -%> -s <%=source%>
+<% end %>
 <% end -%>
 ip46tables -A <%=chain%>-input -p <%=proto%> -m <%=proto%> --dport <%=port%><% if @source -%> -s <%=source%><% end -%> -j ACCEPT -m comment --comment '<%=@name%>'
 <% end -%>

--- a/manifests/resources/meta.pp
+++ b/manifests/resources/meta.pp
@@ -11,6 +11,7 @@ class ffnord::resources::meta {
        ensure => present,
        provider => git,
        source => "https://github.com/freifunk/icvpn-scripts.git",
+       revision => "e5bb5a6948a136453ae1cbe2b27a705f86526579",
        require => [
          Vcsrepo['/var/lib/icvpn-meta/'],
          Package['python-yaml']

--- a/manifests/tinc.pp
+++ b/manifests/tinc.pp
@@ -53,8 +53,8 @@ class ffnord::tinc (
       require => Vcsrepo['/etc/tinc/icvpn/'],
       mode => '0755';
     '/etc/tinc/icvpn/.git/hooks/post-merge':
-      ensure => file,
-      source => "/etc/tinc/icvpn/scripts/post-merge",
+      ensure => link,
+      target => "/etc/tinc/icvpn/scripts/post-merge",
       require => Vcsrepo['/etc/tinc/icvpn/'],
       mode => '0755';
    '/etc/apt/preferences.d/tinc':


### PR DESCRIPTION
Fixed revisions for repositories which are not pulled cron based, but are essential for gateway functionality. This way we can change behavior and upgrade the revisions via puppet script and
don't have to upgrade those manually. This should fix #113.

Also fixing some minor glitches which arise during the last puppet run on ffki-vpn0 and during
the latest test run.