### PR TITLE
ntp: add restrict clause for each ntp server, high stratum for local ref

### DIFF
--- a/files/etc/ntp.conf
+++ b/files/etc/ntp.conf
@@ -10,15 +10,22 @@ filegen peerstats file peerstats type day enable
 filegen clockstats file clockstats type day enable
 
 server 127.127.1.0
+fudge  127.127.1.0 stratum 10
 
-server 0.debian.pool.ntp.org iburst
-server 1.debian.pool.ntp.org iburst
-server 2.debian.pool.ntp.org iburst
-server 3.debian.pool.ntp.org iburst
+server ptbtime1.ptb.de
+server ptbtime2.ptb.de
+server ptbtime3.ptb.de
 
 # Restrict all incoming connection
 restrict -4 default ignore
 restrict -6 default ignore
+
+# ptbtime1.ptb.de
+restrict 192.53.103.108 nomodify notrap nopeer noquery
+# ptbtime2.ptb.de
+restrict 192.53.103.104 nomodify notrap nopeer noquery
+# ptbtime3.ptb.de
+restrict 192.53.103.103 nomodify notrap nopeer noquery
 
 # Local users may interrogate the ntp server more closely.
 restrict 127.0.0.1


### PR DESCRIPTION
restrict clauses needed (with IP addresses) otherwise no sync possible,
the high stratum for the local ref clock is set so that it will only
be used if no other server is reachable