### PR TITLE
Firewall refresh

### DIFF
--- a/files/etc/iptables.d/001-CHAINS
+++ b/files/etc/iptables.d/001-CHAINS
@@ -5,14 +5,22 @@
 ip46tables -N input
 ip46tables -N bat-input
 ip46tables -N mesh-input
+ip46tables -N uplink-input
+ip46tables -N icvpn-input
+ip46tables -N peering-input
 ip46tables -N wan-input
 
 # Default Forward Chains
 
-ip46tables -N forward
-ip46tables -N bat-forward
-ip46tables -N mesh-forward
-ip46tables -N wan-forward
+ip46tables -N fwd-in
+ip46tables -N mesh-fwd-in
+ip46tables -N mesh-fwd-out
+ip46tables -N uplink-fwd-in
+ip46tables -N uplink-fwd-out
+ip46tables -N icvpn-fwd-in
+ip46tables -N icvpn-fwd-out
+ip46tables -N peering-fwd-in
+ip46tables -N peering-fwd-out
 
 # Helper Chains
 

--- a/files/etc/iptables.d/050-FORWARD-PreProcessing
+++ b/files/etc/iptables.d/050-FORWARD-PreProcessing
@@ -10,10 +10,10 @@ ip4tables -A FORWARD -p icmp -j ACCEPT
 ip6tables -A FORWARD -p icmpv6 -j ACCEPT
 
 # udp specific connection tracking
-ip46tables -A FORWARD -p udp -m conntrack --ctstate NEW -j forward
+ip46tables -A FORWARD -p udp -m conntrack --ctstate NEW -j fwd-in
 ip4tables -A FORWARD -p udp -j REJECT --reject-with icmp-port-unreachable
 ip6tables -A FORWARD -p udp -j REJECT --reject-with icmp6-port-unreachable
 
 # tcp specific connection tracking
-ip46tables -A FORWARD -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -m conntrack --ctstate NEW -j forward
+ip46tables -A FORWARD -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -m conntrack --ctstate NEW -j fwd-in
 ip46tables -A FORWARD -p tcp -j REJECT --reject-with tcp-reset

--- a/files/etc/iptables.d/900-FORWARD-drop
+++ b/files/etc/iptables.d/900-FORWARD-drop
@@ -1,6 +1,11 @@
 # Drop all packages which are not ACCEPTed to this point
 ip46tables -A FORWARD -j DROP
-ip46tables -A forward -j DROP
-ip46tables -A bat-forward  -j DROP
-ip46tables -A mesh-forward -j DROP
-ip46tables -A wan-forward  -j DROP
+ip46tables -A fwd-in -j DROP
+ip46tables -A mesh-fwd-in -j DROP
+ip46tables -A mesh-fwd-out -j DROP
+ip46tables -A uplink-fwd-in -j DROP
+ip46tables -A uplink-fwd-out -j DROP
+ip46tables -A icvpn-fwd-in -j DROP
+ip46tables -A icvpn-fwd-out -j DROP
+ip46tables -A peering-fwd-in -j DROP
+ip46tables -A peering-fwd-out -j DROP

--- a/manifests/batman-adv.pp
+++ b/manifests/batman-adv.pp
@@ -31,8 +31,4 @@ define ffnord::batman-adv( $mesh_code
       scriptname => "batman-visible-gateway-count",
       sudo => true;
   }
-
-  ffnord::firewall::device { "bat-${mesh_code}":
-    chain => "bat"
-  } 
 }

--- a/manifests/bridge.pp
+++ b/manifests/bridge.pp
@@ -34,9 +34,9 @@ define ffnord::bridge( $mesh_code
                  ];
   } ->
   ffnord::firewall::device { "br-${mesh_code}":
-    chain => "mesh"
-  } ->
-  ffnord::firewall::forward { "br-${mesh_code}":
-    chain => "mesh"
-  }
+    zone => "mesh",
+    zone_forward_ipv4 => ['mesh','icvpn'],
+    zone_forward_ipv6 => ['mesh','icvpn'],
+    forward_conntrack => false
+  } 
 }

--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -2,22 +2,27 @@
  *  
  * We simple define the firewall rules by putting them into ordered files.
  * This way we can place new rules at any position into the chains.
- * The predefined ruleset first resets the Xtables rulesets and 
- * handles connection tracking, jumping the packages into seperated
- * chains or directly drop them. 
- * Packages accepted for further processing are then be sorted into
- * zone specific chaines. 
  * 
- * We have two zones in this setup: mesh and wan
- * Each with a forward and a input chain: mesh-forward, mesh-input, ...
+ * The general processing idea is to define a zone for each device handled
+ * and define which zones are allowed to forward traffic trough this device.
+ * According to the device definition forwarding packages may be handled
+ * by connection tracking. Traffic from a zone is then processed
+ * through a zone forward chain and pre-filtered before passed to the
+ * destination device chain.
+ * 
+ * We have four zones in this setup: mesh, uplink, icvpn, peering.
+ * Each with a forward input, forward output and a input chain, e.g: 
+ *   mesh-fwd-in, mesh-fwd-out and mesh-input.
  * 
  * The order of execution is matched to meaning by the following list:
  * 
  * 000 RESET all the rules
- * 050 Preprocessing
+ * 025 Pre conntrack forward handling
+ * 050 Connection Tracking
  * 100 Zone selection
  * 500+ Service/Port acceptance
- * 800 Forwarding acceptance
+ * 700 Zone-Device forwarding handling
+ * 850 Forwarding acceptance
  * 900 Drop the rest
  * 900+ Mangle/Postrouting handling
  *
@@ -140,7 +145,9 @@ class ffnord::firewall (
   }
 
   ffnord::firewall::device { $wan_devices:
-    chain => 'wan';
+    zone => 'wan',
+    inter_zone_forward => false,
+    forward_conntrack => true;
   }
 }
 
@@ -165,13 +172,13 @@ define ffnord::firewall::service (
 <% if @ports.length > 0 -%>
 <% @ports.each do |port| -%>
 <% if @rate_limit -%>
-rate_limit46 \"<%=@name%>\" <%=@rate_limit_seconds%> <%=@rate_limit_hitcount%> -A <%=chain%>-input -p <%=proto%> -m <%=proto%> --dport <%=port%><% if @source -%> -s <%=source%>
+rate_limit46 \"<%=@name%>\" <%=@rate_limit_seconds%> <%=@rate_limit_hitcount%> -A <%=chain%>-input -p <%=proto%> -m <%=proto%> --dport <%=port%><% if @source -%> -s <%=@source%>
 <% end %>
 <% end -%>
-ip46tables -A <%=chain%>-input -p <%=proto%> -m <%=proto%> --dport <%=port%><% if @source -%> -s <%=source%><% end -%> -j ACCEPT -m comment --comment '<%=@name%>'
+ip46tables -A <%=chain%>-input -p <%=proto%> -m <%=proto%> --dport <%=port%><% if @source -%> -s <%=@source%><% end -%> -j ACCEPT -m comment --comment '<%=@name%>'
 <% end -%>
 <% else %>
-ip46tables -A <%=chain%>-input -p <%=proto%><% if @source -%> -s <%=source%><% end -%> -j ACCEPT -m comment --comment '<%=@name%>'
+ip46tables -A <%=chain%>-input -p <%=proto%><% if @source -%> -s <%=@source%><% end -%> -j ACCEPT -m comment --comment '<%=@name%>'
 <% end -%>
 <% end -%>
 <% end -%>
@@ -179,43 +186,99 @@ ip46tables -A <%=chain%>-input -p <%=proto%><% if @source -%> -s <%=source%><% e
  }
 }
 
-# Process packages from devices into the chains
+# Process packages from devices
 define ffnord::firewall::device (
-  $chain = "mesh" # Possible values are "mesh","wan"
+  $zone = "mesh",  # Possible values are "mesh","wan","uplink","icvpn"
+  $zone_forward_ipv4 = [], # which zones are allowed to forward ipv4 traffic through this device
+  $zone_forward_ipv6 = [], # which zones are allowed to forward ipv6 traffic through this device 
+  $inter_zone_forward = true, 
+  $forward_conntrack,  # shall forwarded traffic be handled by connection tracking
 ) {
 
- include ffnord::firewall
+  include ffnord::firewall
 
- file { "/etc/iptables.d/100-device-${name}": 
-   ensure => file,
-   owner => "root",
-   group => "root",
-   mode => "0644",
-   content => inline_template("# Process packages from device <%=@name%>
-ip46tables -A input -i <%=@name%> -j <%=@chain%>-input
-ip46tables -A forward -i <%=@name%> -j <%=@chain%>-forward
+  # 002 - Define device specific chain, for forwarded output.
+  #       ZONE-fwd-INTERFACENAME-out
+  if size($zone_forward_ipv4) + size($zone_forward_ipv6) > 0 or $inter_zone_forward {
+    file { "/etc/iptables.d/002-device-chains-${name}": 
+      ensure => file,
+      owner => "root",
+      group => "root",
+      mode => "0644",
+      content => inline_template("# Allow zone forwarding for device <%=@name%>
+ip46tables -N <%=@zone%>-fwd-<%=@name%>-out
 "),
-   require => [File['/etc/iptables.d/']];
- }
-}
+      require => [File['/etc/iptables.d/']];
+    }
+  }
 
-# Allow device for mesh forwarding
-define ffnord::firewall::forward (
-  $chain = "mesh" # Possible values are "mesh","wan"
-) {
+  # 025 - When traffic should not be handled by connection tracking we have to jump
+  #       it directly to the fwd-in chain, for further processing.
+  if ! $forward_conntrack {
+    file { "/etc/iptables.d/025-forward-device-${name}":
+      ensure => "file",
+      owner => "root",
+      group => "root",
+      mode => "0644",
+      content => inline_template("# Jump packages to the forward-in chain before conntrack
+ip46tables -A FORWARD -i <%=@name%> -j fwd-in
+")
+    }
+  }
 
- include ffnord::firewall
-
- file { "/etc/iptables.d/800-${chain}-forward-ACCEPT-${name}": 
-   ensure => file,
-   owner => "root",
-   group => "root",
-   mode => "0644",
-   content => inline_template("# Process packages from device <%=@name%>
-ip46tables -A mesh-forward -o <%=@name%> -j ACCEPT
+  # 100 - Jump packages to zone chains.
+  file { "/etc/iptables.d/100-device-${name}": 
+    ensure => file,
+    owner => "root",
+    group => "root",
+    mode => "0644",
+    # instead of the chain-fwd-out we shall jump to chain-fwd-in and check for e.g. source
+    content => inline_template("# Process packages from device <%=@name%>
+ip46tables -A input -i <%=@name%> -j <%=@zone%>-input
+<% if @inter_zone_forward -%>
+# Inter-Zone-Traffic is allowed for this device.
+ip46tables -A fwd-in -i <%=@name%> -j <%=@zone%>-fwd-<%=@name%>-out
+<% end -%>
 "),
-   require => [File['/etc/iptables.d/']];
- }
+    require => [File['/etc/iptables.d/']];
+  }
+
+  file { "/etc/iptables.d/800-${chain}-forward-ACCEPT-${name}": 
+    ensure => absent;
+  }
+
+  # 700 - Accepting packages from other zones, for the device specific output chain.
+  if size($zone_forward_ipv4) + size($zone_forward_ipv6) > 0 or $inter_zone_forward {
+    file { "/etc/iptables.d/700-forward-transfer-${name}": 
+      ensure => file,
+  	  owner => "root",
+      group => "root",
+      mode => "0644",
+      content => inline_template("# Process packages to device <%=@name%>
+<% @zone_forward_ipv4.each do |zone_ipv4| -%>
+ip4tables -A <%=zone_ipv4%>-fwd-in -o <%=@name%> -j <%=@zone%>-fwd-<%=@name%>-out
+<% end -%>
+<% @zone_forward_ipv6.each do |zone_ipv6| -%>
+ip4tables -A <%=zone_ipv6%>-fwd-in -o <%=@name%> -j <%=@zone%>-fwd-<%=@name%>-out
+<% end -%>
+"),
+  	  require => [File['/etc/iptables.d/']];
+    }
+  }
+
+  # 850 - Accept all remaining packages on the device specific output chain.
+  if size($zone_forward_ipv4) + size($zone_forward_ipv6) > 0 or $inter_zone_forward {
+    file { "/etc/iptables.d/850-${chain}-forward-ACCEPT-${name}": 
+  	  ensure => file,
+  	  owner => "root",
+  	  group => "root",
+  	  mode => "0644",
+  	  content => inline_template("# Finally accept all remaining forward packages for <%=@name%>
+ip46tables -A <%=@zone%>-fwd-<%=@name%>-out -j ACCEPT
+"),
+      require => [File['/etc/iptables.d/']];
+    }
+  }
 }
 
 define ffnord::firewall::set_value(

--- a/manifests/tinc.pp
+++ b/manifests/tinc.pp
@@ -100,11 +100,10 @@ class ffnord::tinc (
   }
 
   ffnord::firewall::device { "icvpn":
-    chain => 'mesh'
-  }
-
-  ffnord::firewall::forward { "icvpn":
-    chain => 'mesh'
+    zone => 'icvpn',
+    zone_forward_ipv4 => ['mesh'],
+    zone_forward_ipv6 => ['mesh'],
+    forward_conntrack => False,
   }
 
   ffnord::firewall::service { "tincd":

--- a/manifests/uplink.pp
+++ b/manifests/uplink.pp
@@ -132,8 +132,11 @@ define ffnord::uplink::tunnel (
     ]
   }
 
-  ffnord::firewall::forward { "uplink-${name}":
-    chain => 'mesh'
+  ffnord::firewall::device { "uplink-${name}":
+    zone => 'uplink',
+    zone_forward_ipv4 => ['mesh'],
+    zone_forward_ipv6 => [''],
+    forward_conntrack => True;
   }
 
   ffnord::firewall::service { "gre-${name}":

--- a/manifests/vpn.pp
+++ b/manifests/vpn.pp
@@ -37,8 +37,10 @@ class ffnord::vpn::provider () {
 
   ffnord::monitor::vnstat::device { 'tun-anonvpn': }
 
-  ffnord::firewall::forward { 'tun-anonvpn':
-    chain => 'mesh'
+  ffnord::firewall::device { "tun-anonvpn":
+    zone => uplink,
+    zone_forward_ipv4 => ['mesh'],
+    forward_conntrack => True,
   }
 
   # Define Firewall rule for masquerade


### PR DESCRIPTION
Implement a new multi zone firewall concept. Which allows to define devices that are not handled by connection tracking. This current state does not implement the also designed ip sets for filtering,
but is a first step into the designated direction.