### PR TITLE
enable multiple fastd instances with different interface ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ ffnord::mesh { 'mesh_ffgc':
       vpn_mac      => "de:ad:be:ff:de:ad",
       mesh_ipv6    => "fd35:f308:a922::ff00/64,
       mesh_ipv4    => "10.35.0.1/19",
-      mesh_mtu     => "1426",
+      mesh_mtu     => "1280",
       range_ipv4   => "10.35.0.0/16",
       mesh_peerings => "/root/mesh_peerings.yaml",
 
       fastd_secret => "/root/fastd_secret.key",
-      fastd_port   => 10035,
+      fastd_port   => 11235,
       fastd_peers_git => 'git://somehost/peers.git',
 
       dhcp_ranges => [ '10.35.0.2 10.35.0.254'
@@ -128,6 +128,18 @@ class {
     openvpn_port   => 3478,
     openvpn_user   => "wayne",
     openvpn_password => "brucessecretpw",
+}
+
+ffnord::fastd { "ffgc_old":
+    mesh_name       => "mesh_ffgc",
+    mesh_code       => "ffgc",
+    mesh_interface  => "ffgc-old",
+    mesh_mac        => "de:ad:be:ee:de:ad",
+    vpn_mac         => "de:ad:be:fe:de:ad",
+    mesh_mtu        => 1460,
+    fastd_secret    => "/root/fastd_secret.conf",
+    fastd_port      => 10000,
+    fastd_peers_git => '/vagrant/fastd/gc/'
 }
 
 ffnord::icvpn::setup {

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ ffnord::fastd { "ffgc_old":
     mesh_interface  => "ffgc-old",
     mesh_mac        => "de:ad:be:ee:de:ad",
     vpn_mac         => "de:ad:be:fe:de:ad",
-    mesh_mtu        => 1460,
+    mesh_mtu        => 1426,
     fastd_secret    => "/root/fastd_secret.conf",
     fastd_port      => 10000,
     fastd_peers_git => '/vagrant/fastd/gc/'

--- a/manifests/fastd.pp
+++ b/manifests/fastd.pp
@@ -3,7 +3,7 @@ define ffnord::fastd( $mesh_name
                      , $mesh_interface # may not be more than 10 characters
                      , $mesh_mac
                      , $vpn_mac
-                     , $mesh_mtu = 1426
+                     , $mesh_mtu = 1280
 
                      , $fastd_secret
                      , $fastd_port

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@ define ffnord::mesh(
   $mesh_as,          # AS of your community
   $mesh_mac,         # mac address mesh device: 52:54:00:bd:e6:d4
   $vpn_mac,          # mac address vpn device, ideally != mesh_mac and unique
-  $mesh_mtu = 1426,  # mtu used, default only suitable for fastd via ipv4
+  $mesh_mtu = 1280,  # mtu used, default only suitable for fastd via ipv4
   $range_ipv4,       # ipv4 range allocated to community in cidr notation, e.g. 10.35.0.1/16
   $mesh_ipv4,        # ipv4 address in cidr notation, e.g. 10.35.0.1/19
   $mesh_ipv6,        # ipv6 address in cidr notation, e.g. fd35:f308:a922::ff00/64
@@ -65,6 +65,7 @@ define ffnord::mesh(
   ffnord::fastd { "fastd_${mesh_code}":
     mesh_name => $mesh_name,
     mesh_code => $mesh_code,
+    mesh_interface => "${mesh_code}",
     mesh_mac  => $mesh_mac,
     vpn_mac   => $vpn_mac,
     mesh_mtu  => $mesh_mtu,

--- a/templates/etc/fastd/fastd.conf.erb
+++ b/templates/etc/fastd/fastd.conf.erb
@@ -1,7 +1,7 @@
 # managed by puppet -- editing is futile
 
-log to syslog as "fastd-<%= @mesh_code %>" level error;
-interface "<%= @mesh_code %>-mesh-vpn";
+log to syslog as "fastd-<%= @mesh_interface %>" level error;
+interface "<%= @mesh_interface %>-mvpn";
 method "salsa2012+umac";    # since fastd v15
 method "salsa2012+gmac";
 method "xsalsa20-poly1305"; # deprecated
@@ -9,8 +9,8 @@ bind any:<%= @fastd_port %>;
 hide ip addresses yes;
 hide mac addresses yes;
 include "secret.conf";
-mtu <%= @mesh_mtu %>; # 1492 - IPv{4,6} Header - fastd Header...
-status socket "/var/run/fastd-status.<%= @mesh_code %>.sock";
+mtu <%= @mesh_mtu %>;
+status socket "/var/run/fastd-status.<%= @mesh_interface %>.sock";
 include peers from "peers";
 on up "
  modprobe batman-adv
@@ -19,5 +19,5 @@ on up "
  ip link set address <%= @mesh_mac %> dev bat-<%= @mesh_code %>
  ifup bat-<%= @mesh_code %>
  ip link set up dev $INTERFACE
- service alfred start bat-<%= @mesh_code %>
+ service alfred start bat-<%= @mesh_code %> # maybe this only at first instance?
 ";


### PR DESCRIPTION
 * the new standard is MTU 1280
 * added $mesh_interface to ffnord::fastd
 * moved old MTU 1426 into example in the README.md as second fastd instances called ${mesh_code}-old