### PR TITLE
Add ping to hide.io config te restart on disconnect due to inactivity

### DIFF
--- a/templates/etc/openvpn/hideio.conf.erb
+++ b/templates/etc/openvpn/hideio.conf.erb
@@ -5,6 +5,9 @@ dev tun-anonvpn
 proto udp
 remote <%= @openvpn_server %> <%= @openvpn_port %>
 cipher AES-128-CBC
+float
+ping 10
+ping-restart 30
 resolv-retry infinite
 nobind
 persist-key


### PR DESCRIPTION
Without these lines on one gateway we got a irregular disconnects every about half an hour with the message

    ovpn-anonvpn [_.hide.me] Inactivity timeout (--ping-restart), restarting

this will ping 

[Manpage](https://community.openvpn.net/openvpn/wiki/Openvpn23ManPage):
> Note that since UDP is connectionless, connection failure is defined by the `--ping` and `--ping-restart` options.   
>`--ping n` - Ping remote over the TCP/UDP control channel if no packets have been sent for at least n seconds  
>`--ping-restart n` -  restart after n seconds pass without reception of a ping or other packet from remote.

(I couldnt acieve this with any `keepalive` setting)