### PR TITLE
Add Travis CI Config for validating puppet module v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: bash
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y python-software-properties
+  - cd /tmp
+  - wget http://apt.puppetlabs.com/puppetlabs-release-precise.deb
+  - sudo dpkg -i puppetlabs-release-precise.deb
+  - sudo apt-get update -qq
+  - sudo apt-get install rubygems
+  - gem install puppet-lint
+  - sudo apt-get install --no-install-recommends puppet git
+  - sudo puppet module install puppetlabs-stdlib
+  - sudo puppet module install puppetlabs-apt --version 1.5.1
+  - sudo puppet module install puppetlabs-vcsrepo
+  - sudo puppet module install saz-sudo
+  - sudo puppet module install torrancew-account
+  - cd /etc/puppet/modules
+  - sudo git clone https://github.com/ffnord/ffnord-puppet-gateway ffnord
+  - cd /home/travis/build/ffnord/ffnord-puppet-gateway
+
+script:
+    - bash tests/validate.sh manifests/
+    - bash puppet parser validate tests/testGW.pp

--- a/tests/validate.sh
+++ b/tests/validate.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ $# -lt 1 ];then
+  echo "$0 .pp-files"
+  exit 1
+fi
+
+for manifest in $*;do
+  echo "Validiere $manifest"
+  puppet parser validate $manifest
+  puppet-lint --no-80chars-check --with-filename $manifest
+done


### PR DESCRIPTION
Rebase of #148 
======

Add an Travis Ci script based on @pinguinpfleger in #144

But be aware that puppet-lint is giving a lot of errors. I did use as Test.pp the puppet script from the README.md and did not change anything in the bash script by @pinguinpfleger

If any of the Admins wanna make this validation trough Travis CI: here is the code for it ;) Tested and working.

Admin Infos
---------------

For adding this here are pro and contra:

**Pro:**

- You can add a badge how the state of the build is
- Automatic Puppetmodule validation

**Contra:**

- one of the admins have to login to https://travis-ci.org and must activate the repo there