### PR TITLE
Fix travis.ci problems with the rubygems package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - wget http://apt.puppetlabs.com/puppetlabs-release-precise.deb
   - sudo dpkg -i puppetlabs-release-precise.deb
   - sudo apt-get update -qq
-  - sudo apt-get install rubygems
+  - sudo apt-get install ruby
   - gem install puppet-lint
   - sudo apt-get install --no-install-recommends puppet git
   - sudo puppet module install puppetlabs-stdlib


### PR DESCRIPTION
Travis CI failed with error "no realease canidate for rubygems".

rumbygems heisst nun ruby. :) mit dieser änderung sollte travis wieder gehen