### PR TITLE
add full path for calling rndc in update-zones

### DIFF
--- a/files/usr/local/bin/update-zones
+++ b/files/usr/local/bin/update-zones
@@ -10,5 +10,5 @@ pull() {
 }
 
 reload() {
-  rndc reload
+  /usr/sbin/rndc reload
 }


### PR DESCRIPTION
when called from crontab, debian jessie requires full path to rndc "update-zones"