### PR TITLE
RADVD: limit RA

### DIFF
--- a/templates/etc/radvd.conf.erb
+++ b/templates/etc/radvd.conf.erb
@@ -4,6 +4,7 @@ interface <%= @interface %>
  AdvSendAdvert on;
  IgnoreIfMissing on;
  MaxRtrAdvInterval 200;
+ UnicastOnly on;
 
  prefix <%= @mesh_ipv6_prefix %>/<%= @mesh_ipv6_prefixlen %>
  {


### PR DESCRIPTION
Als Reaktion auf:
http://freifunk-stuttgart.de/2016/01/22/ipv6-router-advertisements-legen-freifunk-router-lahm/

> Was war passiert?
> 
> Im FFS-Netz war die Anzahl IPv6 Router Advertisement Pakete (RA) auf eine so hohe Zahl gestiegen, dass die Router diese nicht mehr in Echtzeit verarbeiten konnten und sich mehrere parallele Prozesse aufgebaut haben, jeder von einem RA getriggert.
> Im obigen Bild sind es noch 3 Prozesse, die auf den ersten Blick unkritisch scheinen, sie führen jedoch auch zu den kworker Prozessen - in der Summe ist es dann nicht mehr vernachlässigbar. Und die Anzahl steigt stetig.
> Im obigen Bild sind es noch 3 Prozesse, die auf den ersten Blick unkritisch scheinen, sie führen jedoch auch zu den kworker Prozessen – in der Summe ist es dann nicht mehr vernachlässigbar. Und die Anzahl steigt stetig.
> 
> Das ging jeweils so lange gut, bis nicht mehr genügend RAM für „Alfred“ zur Verfügung stand. In diesem Zustand stieg die CPU-Last noch stärker an, gleichzeitig wurde das freie RAM knapper, was schließlich im Kollaps des Routers endete. Bevor er sich entweder festfraß oder neu startete, wurde noch batman-adv in Mitleidenschaft gezogen und hat die Mesh-Pakete unkontrolliert weitergeleitet – daher die Schein-Loops.
