### PR TITLE
Install apt-transport-https before fetching fastd sources

### DIFF
--- a/manifests/resources/repos.pp
+++ b/manifests/resources/repos.pp
@@ -1,15 +1,19 @@
 class ffnord::resources::repos (
   $debian_mirror = $ffnord::params::debian_mirror
 ) inherits ffnord::params {
+  package { 
+    'apt-transport-https':
+      ensure => installed;
+  } ->
   apt::source { 'repo.universe-factory':
-    location   => 'http://repo.universe-factory.net/debian/',
+    location   => 'https://repo.universe-factory.net/debian/',
     release    => 'sid',
     repos      => 'main',
     key        => '16EF3F64CB201D9C',
     key_server => 'pgpkeys.mit.edu';
   }
 
- apt::source { 'debian.draic.info':
+  apt::source { 'debian.draic.info':
     location    => 'http://debian.draic.info/',
     release     => 'wheezy',
     repos       => 'main',


### PR DESCRIPTION
Otherwise puppet cannot fetch from https://repo.universe-factory.net/