### PR TITLE
More logging, (gw|vpn)-watchdog in check-gateway zusammenführen

### DIFF
--- a/files/usr/local/bin/check-gateway
+++ b/files/usr/local/bin/check-gateway
@@ -9,7 +9,7 @@ MAINTENANCE=${MAINTENANCE:-0}
 ping_test(){
     count=20
     for x in $(seq 1 "$count"); do
-      ping -q -m 1 $GW_CONTROL_IP -c 1 -i 1 -W 2 # >/dev/null 2>&1
+      ping -q -m 1 $GW_CONTROL_IP -c 1 -i 1 -W 2 >/dev/null 2>&1
       if test $?; then
         count=$(expr "$count" - 1)
       fi

--- a/files/usr/local/bin/check-gateway
+++ b/files/usr/local/bin/check-gateway
@@ -21,14 +21,14 @@ if test $MAINTENANCE -eq 0; then
         /sbin/ip rule add from all fwmark 0x1 unreachable preference 32001
     fi
 
-    log "Trying to get a reply from $GW_CONTROL_IP..."
+    logger "Trying to get a reply from $GW_CONTROL_IP..."
     ping -q -m 1 $GW_CONTROL_IP -c 4 -i 1 -W 5 >/dev/null 2>&1
 
     if test $? -eq 0; then
-        log "Got a reply from $GW_CONTROL_IP, so everything seems to be in order."
+        logger "Got a reply from $GW_CONTROL_IP, so everything seems to be in order."
         NEW_STATE=server
     else
-        log "Did not get a reply from $GW_CONTROL_IP, so there seems to be a problem."
+        logger "Did not get a reply from $GW_CONTROL_IP, so there seems to be a problem."
         NEW_STATE=off
     fi
 
@@ -63,7 +63,7 @@ done
 if test $MAINTENANCE -eq 0; then
     if [ "$OLD_STATE" != "$NEW_STATE" ] && [ "$NEW_STATE" == "off" ]; then
       /usr/sbin/service openvpn restart
-      log "Restart VPN to regain VPN connectivity!"
+      logger "Restart VPN to regain VPN connectivity!"
     fi
 fi
 

--- a/files/usr/local/bin/check-gateway
+++ b/files/usr/local/bin/check-gateway
@@ -21,14 +21,14 @@ if test $MAINTENANCE -eq 0; then
         /sbin/ip rule add from all fwmark 0x1 unreachable preference 32001
     fi
 
-    logger -p daemon.info "Trying to get a reply from $GW_CONTROL_IP..."
+    logger -t check-gateway -p daemon.info "Trying to get a reply from $GW_CONTROL_IP..."
     ping -q -m 1 $GW_CONTROL_IP -c 4 -i 1 -W 5 >/dev/null 2>&1
 
     if test $? -eq 0; then
-        logger -p daemon.info "Got a reply from $GW_CONTROL_IP, so everything seems to be in order."
+        logger -t check-gateway -p daemon.info "Got a reply from $GW_CONTROL_IP, so everything seems to be in order."
         NEW_STATE=server
     else
-        logger -p daemon.err -s "Did not get a reply from $GW_CONTROL_IP, so there seems to be a problem."
+        logger -t check-gateway -p daemon.err -s "Did not get a reply from $GW_CONTROL_IP, so there seems to be a problem."
         NEW_STATE=off
     fi
 
@@ -40,11 +40,11 @@ for MESH in /sys/class/net/*/mesh; do
 OLD_STATE="$(cat $MESH/gw_mode)"
 [ "$OLD_STATE" == "$NEW_STATE" ] && continue
     echo $NEW_STATE > $MESH/gw_mode
-    logger -p daemon.notice -s "batman gateway mode changed to $NEW_STATE"
+    logger -t check-gateway -p daemon.notice -s "batman gateway mode changed to $NEW_STATE"
 
     # Check whether gateway modus has been deactivated
     if [ "$NEW_STATE" == "off" ]; then
-        logger -p daemon.notice -s "stopping isc-dhcp-server and radvd"
+        logger -t check-gateway -p daemon.notice -s "stopping isc-dhcp-server and radvd"
         # Shutdown DHCP server to prevent renewal of leases
         /usr/sbin/service isc-dhcp-server stop
         # Shutdown RAdv server to prevent announcement of IPv6 routing prefixes
@@ -53,7 +53,7 @@ OLD_STATE="$(cat $MESH/gw_mode)"
 
     # Check whether gateway modus has been activated
     if [ "$NEW_STATE" == "server" ]; then
-        logger -p daemon.notice -s "starting isc-dhcp-server and radvd"
+        logger -t check-gateway -p daemon.notice -s "starting isc-dhcp-server and radvd"
         # Restart DHCP server
         /usr/sbin/service isc-dhcp-server start
         /usr/sbin/service radvd start
@@ -65,7 +65,7 @@ done
 if test $MAINTENANCE -eq 0; then
     if [ "$OLD_STATE" != "$NEW_STATE" ] && [ "$NEW_STATE" == "off" ]; then
       /usr/sbin/service openvpn restart
-      logger -p daemon.notice -s "Restart VPN to regain VPN connectivity!"
+      logger -t check-gateway -p daemon.notice -s "Restart VPN to regain VPN connectivity!"
     fi
 fi
 
@@ -74,7 +74,7 @@ if [ "$NEW_STATE" == "server" ]; then
       /usr/sbin/service $service status 2>&1> /dev/null
       if [[ $? -ne 0 ]]
       then
-          logger -p daemon.notice -s "restarting $service"
+          logger -t check-gateway -p daemon.notice -s "restarting $service"
           /usr/sbin/service $service restart
       fi
     done
@@ -84,7 +84,7 @@ if [ "$NEW_STATE" == "off" ]; then
       /usr/sbin/service $service status 2>&1> /dev/null
       if [[ $? -eq 0 ]]
       then
-          logger -p daemon.notice -s "stopping $service"
+          logger -t check-gateway -p daemon.notice -s "stopping $service"
           /usr/sbin/service $service stop
       fi
     done

--- a/files/usr/local/bin/check-gateway
+++ b/files/usr/local/bin/check-gateway
@@ -21,11 +21,14 @@ if test $MAINTENANCE -eq 0; then
         /sbin/ip rule add from all fwmark 0x1 unreachable preference 32001
     fi
 
+    log "Trying to get a reply from $GW_CONTROL_IP..."
     ping -q -m 1 $GW_CONTROL_IP -c 4 -i 1 -W 5 >/dev/null 2>&1
 
     if test $? -eq 0; then
+        log "Got a reply from $GW_CONTROL_IP, so everything seems to be in order."
         NEW_STATE=server
     else
+        log "Did not get a reply from $GW_CONTROL_IP, so there seems to be a problem."
         NEW_STATE=off
     fi
 

--- a/files/usr/local/bin/check-gateway
+++ b/files/usr/local/bin/check-gateway
@@ -59,6 +59,14 @@ OLD_STATE="$(cat $MESH/gw_mode)"
     exit 0
 done
 
+#Fiddle with the vpn
+if test $MAINTENANCE -eq 0; then
+    if [ "$OLD_STATE" != "$NEW_STATE" ] && [ "$NEW_STATE" == "off" ]; then
+      /usr/sbin/service openvpn restart
+      log "Restart VPN to regain VPN connectivity!"
+    fi
+fi
+
 if [ "$NEW_STATE" == "server" ]; then
     for service in isc-dhcp-server radvd; do
       /usr/sbin/service $service status 2>&1> /dev/null

--- a/files/usr/local/bin/check-gateway
+++ b/files/usr/local/bin/check-gateway
@@ -28,7 +28,7 @@ if test $MAINTENANCE -eq 0; then
         logger -t check-gateway -p daemon.info "Got a reply from $GW_CONTROL_IP, so everything seems to be in order."
         NEW_STATE=server
     else
-        logger -t check-gateway -p daemon.err -s "Did not get a reply from $GW_CONTROL_IP, so there seems to be a problem."
+        logger -t check-gateway -p daemon.err "Did not get a reply from $GW_CONTROL_IP, so there seems to be a problem."
         NEW_STATE=off
     fi
 

--- a/files/usr/local/bin/check-gateway
+++ b/files/usr/local/bin/check-gateway
@@ -43,29 +43,36 @@ OLD_STATE="$(cat $MESH/gw_mode)"
     if [ "$NEW_STATE" == "off" ]; then
         # Shutdown DHCP server to prevent renewal of leases
         /usr/sbin/service isc-dhcp-server stop
+        # Shutdown RAdv server to prevent announcement of IPv6 routing prefixes
+        /usr/sbin/service radvd stop
     fi
 
     # Check whether gateway modus has been activated
     if [ "$NEW_STATE" == "server" ]; then
         # Restart DHCP server
         /usr/sbin/service isc-dhcp-server start
+        /usr/sbin/service radvd start
     fi
     exit 0
 done
 
 if [ "$NEW_STATE" == "server" ]; then
-    /usr/sbin/service isc-dhcp-server status 2>&1> /dev/null
-    if [[ $? -ne 0 ]]
-    then
-        /usr/sbin/service isc-dhcp-server restart
-    fi
+    for service in isc-dhcp-server radvd; do
+      /usr/sbin/service $service status 2>&1> /dev/null
+      if [[ $? -ne 0 ]]
+      then
+          /usr/sbin/service $service restart
+      fi
+    done
 fi
 if [ "$NEW_STATE" == "off" ]; then
-    /usr/sbin/service isc-dhcp-server status 2>&1> /dev/null
-    if [[ $? -eq 0 ]]
-    then
-        /usr/sbin/service isc-dhcp-server stop
-    fi
+    for service in isc-dhcp-server radvd; do
+      /usr/sbin/service $service status 2>&1> /dev/null
+      if [[ $? -eq 0 ]]
+      then
+          /usr/sbin/service $service stop
+      fi
+    done
 fi
 
 # vim: noai:ts=4:sw=4:ff=unix:ft=text:fdm=marker

--- a/files/usr/local/bin/check-gateway
+++ b/files/usr/local/bin/check-gateway
@@ -21,14 +21,14 @@ if test $MAINTENANCE -eq 0; then
         /sbin/ip rule add from all fwmark 0x1 unreachable preference 32001
     fi
 
-    logger "Trying to get a reply from $GW_CONTROL_IP..."
+    logger -p daemon.info "Trying to get a reply from $GW_CONTROL_IP..."
     ping -q -m 1 $GW_CONTROL_IP -c 4 -i 1 -W 5 >/dev/null 2>&1
 
     if test $? -eq 0; then
-        logger "Got a reply from $GW_CONTROL_IP, so everything seems to be in order."
+        logger -p daemon.info "Got a reply from $GW_CONTROL_IP, so everything seems to be in order."
         NEW_STATE=server
     else
-        logger "Did not get a reply from $GW_CONTROL_IP, so there seems to be a problem."
+        logger -p daemon.err -s "Did not get a reply from $GW_CONTROL_IP, so there seems to be a problem."
         NEW_STATE=off
     fi
 
@@ -40,10 +40,11 @@ for MESH in /sys/class/net/*/mesh; do
 OLD_STATE="$(cat $MESH/gw_mode)"
 [ "$OLD_STATE" == "$NEW_STATE" ] && continue
     echo $NEW_STATE > $MESH/gw_mode
-    logger "batman gateway mode changed to $NEW_STATE"
+    logger -p daemon.notice -s "batman gateway mode changed to $NEW_STATE"
 
     # Check whether gateway modus has been deactivated
     if [ "$NEW_STATE" == "off" ]; then
+        logger -p daemon.notice -s "stopping isc-dhcp-server and radvd"
         # Shutdown DHCP server to prevent renewal of leases
         /usr/sbin/service isc-dhcp-server stop
         # Shutdown RAdv server to prevent announcement of IPv6 routing prefixes
@@ -52,6 +53,7 @@ OLD_STATE="$(cat $MESH/gw_mode)"
 
     # Check whether gateway modus has been activated
     if [ "$NEW_STATE" == "server" ]; then
+        logger -p daemon.notice -s "starting isc-dhcp-server and radvd"
         # Restart DHCP server
         /usr/sbin/service isc-dhcp-server start
         /usr/sbin/service radvd start
@@ -63,7 +65,7 @@ done
 if test $MAINTENANCE -eq 0; then
     if [ "$OLD_STATE" != "$NEW_STATE" ] && [ "$NEW_STATE" == "off" ]; then
       /usr/sbin/service openvpn restart
-      logger "Restart VPN to regain VPN connectivity!"
+      logger -p daemon.notice -s "Restart VPN to regain VPN connectivity!"
     fi
 fi
 
@@ -72,6 +74,7 @@ if [ "$NEW_STATE" == "server" ]; then
       /usr/sbin/service $service status 2>&1> /dev/null
       if [[ $? -ne 0 ]]
       then
+          logger -p daemon.notice -s "restarting $service"
           /usr/sbin/service $service restart
       fi
     done
@@ -81,6 +84,7 @@ if [ "$NEW_STATE" == "off" ]; then
       /usr/sbin/service $service status 2>&1> /dev/null
       if [[ $? -eq 0 ]]
       then
+          logger -p daemon.notice -s "stopping $service"
           /usr/sbin/service $service stop
       fi
     done

--- a/files/usr/local/bin/check-gateway
+++ b/files/usr/local/bin/check-gateway
@@ -72,14 +72,6 @@ OLD_STATE="$(cat $MESH/gw_mode)"
     exit 0
 done
 
-#Fiddle with the vpn
-if test $MAINTENANCE -eq 0; then
-    if [ "$OLD_STATE" != "$NEW_STATE" ] && [ "$NEW_STATE" == "off" ]; then
-      /usr/sbin/service openvpn restart
-      logger -t check-gateway -p daemon.notice -s "Restart VPN to regain VPN connectivity!"
-    fi
-fi
-
 if [ "$NEW_STATE" == "server" ]; then
     for service in isc-dhcp-server radvd; do
       /usr/sbin/service $service status 2>&1> /dev/null

--- a/files/usr/local/bin/check-gateway
+++ b/files/usr/local/bin/check-gateway
@@ -6,6 +6,17 @@ shopt -s nullglob
 
 MAINTENANCE=${MAINTENANCE:-0}
 
+ping_test(){
+    count=20
+    for x in $(seq 1 "$count"); do
+      ping -q -m 1 $GW_CONTROL_IP -c 1 -i 1 -W 2 # >/dev/null 2>&1
+      if test $?; then
+        count=$(expr "$count" - 1)
+      fi
+    done
+    return "$count"
+}
+ 
 if test $MAINTENANCE -eq 0; then
 
     # ensure that we have the appropriate rules
@@ -22,9 +33,9 @@ if test $MAINTENANCE -eq 0; then
     fi
 
     logger -t check-gateway -p daemon.info "Trying to get a reply from $GW_CONTROL_IP..."
-    ping -q -m 1 $GW_CONTROL_IP -c 4 -i 1 -W 5 >/dev/null 2>&1
+    ping_test
 
-    if test $? -eq 0; then
+    if test $? -lt 2; then
         logger -t check-gateway -p daemon.info "Got a reply from $GW_CONTROL_IP, so everything seems to be in order."
         NEW_STATE=server
     else


### PR DESCRIPTION
Mehr logging
- in daemon.log mit dem tag "check-gateway" ausgeben, sowie auf stderr im Fehlerfall, sodass der cronjob auch diese Meldungen enthält.



Daemon die ebenfals nach nichterreichbarkeit der IP beendet/neugestartet werden:
- [x] radvd
- [x] openvpn
