### PR TITLE
Invalid parameter gw_control_ip

### DIFF
--- a/manifests/vpn.pp
+++ b/manifests/vpn.pp
@@ -1,6 +1,5 @@
 class ffnord::vpn (
   $gw_vpn_interface  = 'tun-anonvpn', # Interface name for the anonymous vpn
-  $gw_control_ip     = '8.8.8.8',     # Control ip addr
   $gw_bandwidth      = 54,            # How much bandwith we should have up/down per mesh interface
 ) {
 

--- a/manifests/vpn.pp
+++ b/manifests/vpn.pp
@@ -1,5 +1,6 @@
 class ffnord::vpn (
   $gw_vpn_interface  = 'tun-anonvpn', # Interface name for the anonymous vpn
+  $gw_control_ip     = '217.70.197.1',     # Control ip addr
   $gw_bandwidth      = 54,            # How much bandwith we should have up/down per mesh interface
 ) {
 
@@ -7,7 +8,7 @@ class ffnord::vpn (
 
   class {
     'ffnord::resources::checkgw':
-      gw_control_ip => $gw_control_ip,
+      gw_control_ips => $gw_control_ip,
       gw_bandwidth => $gw_bandwidth,
   }
 }


### PR DESCRIPTION
If I run puppet, I get 

    Invalid parameter gw_control_ip at /etc/puppet/modules/ffnord/manifests/vpn.pp:13 

would this fix it? Maybe this is also wrong.

please try out the ffnord-example to fix this.