### PR TITLE
PIA: route-noexec ergänzt

### DIFF
--- a/templates/etc/openvpn/pia.conf.erb
+++ b/templates/etc/openvpn/pia.conf.erb
@@ -19,4 +19,5 @@ crl-verify /etc/openvpn/pia/crl.rsa.2048.pem
 ca pia/ca.rsa.2048.crt
 disable-occ
 script-security 2
+route-noexec
 up anonvpn-up.sh


### PR DESCRIPTION
route-noexec fehlte in der anonvpn.conf